### PR TITLE
Implement version flag and silence command

### DIFF
--- a/src/bingbong/__init__.py
+++ b/src/bingbong/__init__.py
@@ -1,1 +1,5 @@
-__all__ = []
+from importlib.metadata import version
+
+__all__ = ["__version__"]
+
+__version__ = version("bingbong")


### PR DESCRIPTION
## Summary
- add package version constant
- support global `--dry-run` and `--version`
- implement new `silence` command that replaces pause/unpause
- test dry-run and silence logic

## Testing
- `pytest -q`


------
https://chatgpt.com/codex/tasks/task_e_6888047b07b08327a3b5234acb55716b