### PR TITLE
feat: streamline schedule rendering and add launchctl wrapper

### DIFF
--- a/TODO.md
+++ b/TODO.md
@@ -1,10 +1,10 @@
-- [ ] Fix minute-type bug
+- [x] Fix minute-type bug
   - Cast `minute` to `int` in `make_schedule` or eliminate manual loops via `LaunchdSchedule.add_cron`.
-- [ ] Simplify schedule generation
+- [x] Simplify schedule generation
   - Move logic from `make_schedule()` into `bingbong.scheduler.render()`, returning a `LaunchdSchedule`.
-- [ ] Remove redundant scheduler methods
+- [x] Remove redundant scheduler methods
   - Eliminate `_minutes_from_cron` and `ChimeScheduler.minutes_for_chime()`.
-- [ ] Suppress cron translation
+- [x] Suppress cron translation
   - Properly convert suppression cron lines (`m h * * *`) into `HH:MM-HH:MM` strings for `add_suppression_window`.
 - [ ] Expose advanced `LaunchBehavior` knobs
   - Add CLI/config options to set `exit_timeout`, `throttle_interval`, `successful_exit`, and `crashed`.

--- a/src/bingbong/cli.py
+++ b/src/bingbong/cli.py
@@ -10,7 +10,7 @@ from croniter import croniter
 from rich.console import Console
 from tomlkit import dumps
 
-from . import notify, service
+from . import launchctl, notify
 from .commands import (
     build as build_cmd,
 )
@@ -64,7 +64,7 @@ def install(ctx: click.Context) -> None:
     if ctx.obj.get("dry_run"):
         click.echo("DRY RUN: would install launchctl job")
         return
-    service.install()
+    launchctl.install()
     click.echo("Installed launchctl job.")
 
 
@@ -75,7 +75,7 @@ def uninstall(ctx: click.Context) -> None:
     if ctx.obj.get("dry_run"):
         click.echo("DRY RUN: would uninstall launchctl job")
         return
-    service.uninstall()
+    launchctl.uninstall()
     click.echo("Uninstalled launchctl job.")
 
 

--- a/src/bingbong/launchctl.py
+++ b/src/bingbong/launchctl.py
@@ -1,0 +1,15 @@
+"""Thin wrappers around launchctl operations."""
+
+from bingbong.scheduler import ChimeScheduler
+from bingbong.service import install as service_install
+from bingbong.service import uninstall as service_uninstall
+
+
+def install(cfg: ChimeScheduler | None = None) -> None:
+    """Install the launchd service."""
+    service_install(cfg)
+
+
+def uninstall() -> None:
+    """Remove the launchd service."""
+    service_uninstall()

--- a/src/bingbong/service.py
+++ b/src/bingbong/service.py
@@ -1,27 +1,11 @@
 import sys
 
-from onginred.schedule import LaunchdSchedule
 from onginred.service import LaunchdService
 
 from bingbong.paths import ensure_outdir
-from bingbong.scheduler import ChimeScheduler
+from bingbong.scheduler import ChimeScheduler, render
 
 LABEL = "com.josephcourtney.bingbong"
-
-
-def make_schedule(cfg: ChimeScheduler) -> LaunchdSchedule:
-    sch = LaunchdSchedule()
-    # Trigger at every hour for each chime minute
-    for minute in cfg.minutes_for_chime():
-        for hour in range(24):
-            sch.time.add_calendar_entry(hour=hour, minute=minute)
-    for rng in cfg.suppress_schedule:
-        # cron “m h …” ⇒ convert to “HH:MM-HH:MM”
-        m, *_ = rng.split()
-        sch.time.add_suppression_window(f"{int(m):02d}:00-{int(m):02d}:00")
-    sch.behavior.run_at_load = True
-    sch.behavior.keep_alive = True
-    return sch
 
 
 def _service(cfg: ChimeScheduler) -> LaunchdService:
@@ -29,7 +13,7 @@ def _service(cfg: ChimeScheduler) -> LaunchdService:
     return LaunchdService(
         bundle_identifier=LABEL,
         command=[sys.executable, "-m", "bingbong", "chime"],
-        schedule=make_schedule(cfg),
+        schedule=render(cfg),
         log_dir=outdir,
         log_name="bingbong",
         create_dir=True,


### PR DESCRIPTION
## Summary
- build schedules with LaunchdSchedule.add_cron via new `scheduler.render`
- wrap launchctl operations and route CLI through wrapper
- translate suppression cron into HH:MM windows and update tests

## Testing
- `ruff format src/bingbong/launchctl.py tests/test_scheduler.py src/bingbong/scheduler.py src/bingbong/service.py >/tmp/ruff_format.log && tail -n 20 /tmp/ruff_format.log`
- `ruff check >/tmp/ruff_check.log && tail -n 20 /tmp/ruff_check.log`
- `pytest >/tmp/pytest.log && tail -n 20 /tmp/pytest.log`

------
https://chatgpt.com/codex/tasks/task_e_6896108ed8908327a8e8054c26af0292