### PR TITLE
feat: add dry-run helper and custom error

### DIFF
--- a/TODO.md
+++ b/TODO.md
@@ -23,12 +23,12 @@
   - Update `README.md` and CLI `--help` output to include advanced scheduling and behavior flags.
 - [ ] Wrap `ffmpeg` in a testable class
   - Create an injectable `FFmpeg` interface to isolate subprocess logic.
-- [ ] Add docstrings for `ChimeScheduler` public API
-- [ ] Use `pathlib.Path` consistently (e.g. in `ffmpeg.concat`)
-- [ ] Convert dry-run checks to decorator
+- [x] Add docstrings for `ChimeScheduler` public API
+- [x] Use `pathlib.Path` consistently (e.g. in `ffmpeg.concat`)
+- [x] Convert dry-run checks to decorator
   - Introduce a reusable `@dryable` decorator to eliminate repeated checks.
 - [ ] Replace `print()` with structured logging
-- [ ] Introduce `BingBongError` domain exception class
+- [x] Introduce `BingBongError` domain exception class
 - [ ] Remove dead code
   - Delete `_render_minimal_start_calendar_interval_plist` (unused).
 - [ ] State Management

--- a/src/bingbong/__init__.py
+++ b/src/bingbong/__init__.py
@@ -1,5 +1,9 @@
+"""Package initialization for bingbong."""
+
 from importlib.metadata import version
 
-__all__ = ["__version__"]
+from .errors import BingBongError
+
+__all__ = ["BingBongError", "__version__"]
 
 __version__ = version("bingbong")

--- a/src/bingbong/cli.py
+++ b/src/bingbong/cli.py
@@ -11,22 +11,13 @@ from rich.console import Console
 from tomlkit import dumps
 
 from . import launchctl, notify
-from .commands import (
-    build as build_cmd,
-)
-from .commands import (
-    doctor as doctor_cmd,
-)
-from .commands import (
-    logs_cmd,
-)
-from .commands import (
-    silence as silence_cmd,
-)
-from .commands import (
-    status as status_cmd,
-)
+from .commands import build as build_cmd
+from .commands import doctor as doctor_cmd
+from .commands import logs_cmd
+from .commands import silence as silence_cmd
+from .commands import status as status_cmd
 from .paths import ensure_outdir
+from .utils import dryable
 
 LOG_ROTATE_SIZE = 10 * 1024 * 1024  # rotate logs larger than 10 MB
 
@@ -59,22 +50,18 @@ def main(ctx: click.Context, *, dry_run: bool) -> None:
 
 @main.command()
 @click.pass_context
-def install(ctx: click.Context) -> None:
+@dryable("would install launchctl job")
+def install(_ctx: click.Context) -> None:
     """Install launchctl job."""
-    if ctx.obj.get("dry_run"):
-        click.echo("DRY RUN: would install launchctl job")
-        return
     launchctl.install()
     click.echo("Installed launchctl job.")
 
 
 @main.command()
 @click.pass_context
-def uninstall(ctx: click.Context) -> None:
+@dryable("would uninstall launchctl job")
+def uninstall(_ctx: click.Context) -> None:
     """Remove launchctl job."""
-    if ctx.obj.get("dry_run"):
-        click.echo("DRY RUN: would uninstall launchctl job")
-        return
     launchctl.uninstall()
     click.echo("Uninstalled launchctl job.")
 
@@ -96,11 +83,9 @@ def clean(ctx: click.Context) -> None:
 
 @main.command()
 @click.pass_context
-def chime(ctx: click.Context) -> None:
+@dryable("would play chime")
+def chime(_ctx: click.Context) -> None:
     """Play the appropriate chime for the current time."""
-    if ctx.obj.get("dry_run"):
-        click.echo("DRY RUN: would play chime")
-        return
     notify.notify_time()
     click.echo("Chime played.")
 

--- a/src/bingbong/commands/build.py
+++ b/src/bingbong/commands/build.py
@@ -4,21 +4,21 @@ import click
 
 from bingbong import audio
 from bingbong.console import err, ok
+from bingbong.errors import BingBongError
 from bingbong.ffmpeg import ffmpeg_available
+from bingbong.utils import dryable
 
 
 @click.command()
 @click.pass_context
-def build(ctx: click.Context) -> None:
+@dryable("would build audio files")
+def build(_ctx: click.Context) -> None:
     """Build composite chime audio files."""
     if not ffmpeg_available():
         err("ffmpeg is not available")
         return
-    if ctx.obj.get("dry_run"):
-        ok("DRY RUN: would build audio files")
-        return
     try:
         audio.build_all()
         ok("Built chime and quarter audio files.")
-    except RuntimeError as e:
+    except (BingBongError, RuntimeError) as e:
         err(str(e))

--- a/src/bingbong/errors.py
+++ b/src/bingbong/errors.py
@@ -1,0 +1,5 @@
+"""Custom exceptions for bingbong."""
+
+
+class BingBongError(Exception):
+    """Base exception for bingbong domain errors."""

--- a/src/bingbong/scheduler.py
+++ b/src/bingbong/scheduler.py
@@ -10,7 +10,15 @@ __all__ = ["ChimeScheduler", "render"]
 
 @dataclass(slots=True)
 class ChimeScheduler:
-    """Manage chime and suppression schedules."""
+    """Manage chime and suppression schedules.
+
+    Attributes
+    ----------
+    chime_schedule:
+        Cron expression defining when a chime should play.
+    suppress_schedule:
+        Cron expressions that specify suppression windows.
+    """
 
     chime_schedule: str = "0 * * * *"
     suppress_schedule: list[str] = field(default_factory=list)
@@ -27,7 +35,7 @@ class ChimeScheduler:
 
 
 def render(cfg: ChimeScheduler) -> LaunchdSchedule:
-    """Create a fully-populated :class:`LaunchdSchedule` from ``cfg``."""
+    """Return a :class:`LaunchdSchedule` populated from ``cfg``."""
     sch = LaunchdSchedule()
     sch.add_cron(cfg.chime_schedule)
     for rng in cfg.suppress_schedule:

--- a/src/bingbong/utils.py
+++ b/src/bingbong/utils.py
@@ -1,0 +1,36 @@
+"""Utility helpers for bingbong."""
+
+from __future__ import annotations
+
+import functools
+from typing import TYPE_CHECKING, ParamSpec, TypeVar
+
+import click
+
+if TYPE_CHECKING:
+    from collections.abc import Callable
+
+P = ParamSpec("P")
+R = TypeVar("R")
+
+
+def dryable(message: str) -> Callable[[Callable[P, R]], Callable[P, R | None]]:
+    """Skip command execution when ``--dry-run`` is set.
+
+    Parameters
+    ----------
+    message:
+        Description of the action that would have been performed.
+    """
+
+    def decorator(func: Callable[P, R]) -> Callable[P, R | None]:
+        @functools.wraps(func)
+        def wrapper(ctx: click.Context, *args: P.args, **kwargs: P.kwargs) -> R | None:
+            if ctx.obj.get("dry_run"):
+                click.echo(f"DRY RUN: {message}")
+                return None
+            return func(ctx, *args, **kwargs)
+
+        return wrapper
+
+    return decorator

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -43,7 +43,7 @@ def patch_ffmpeg(monkeypatch):
 
     def fake_run(args, **_kwargs):
         # Detect silence creation
-        if any("anullsrc" in arg for arg in args):
+        if any("anullsrc" in str(arg) for arg in args):
             path = Path(args[-1])
             path.parent.mkdir(parents=True, exist_ok=True)
             path.touch()

--- a/tests/test_ffmpeg.py
+++ b/tests/test_ffmpeg.py
@@ -3,6 +3,7 @@ import shutil
 import subprocess
 
 import pytest
+from bingbong.errors import BingBongError
 
 from bingbong import audio, ffmpeg, paths
 from bingbong.audio import concat, make_silence
@@ -11,7 +12,7 @@ from bingbong.audio import concat, make_silence
 def test_concat_ffmpeg_missing(monkeypatch, tmp_path):
     # If FFMPEG is None, concat should fail immediately
     monkeypatch.setattr(ffmpeg, "find_ffmpeg", lambda: None)
-    with pytest.raises(RuntimeError):
+    with pytest.raises(BingBongError):
         concat([], tmp_path / "out.wav")
 
 
@@ -38,11 +39,11 @@ def test_make_silence_creates_file(tmp_path):
 
 def test_concat_runtime_error(monkeypatch, tmp_path):
     monkeypatch.setattr("bingbong.ffmpeg.find_ffmpeg", lambda: None)
-    with pytest.raises(RuntimeError, match="ffmpeg is not available"):
+    with pytest.raises(BingBongError, match="ffmpeg is not available"):
         ffmpeg.concat(["a.wav", "b.wav"], tmp_path / "out.wav")
 
 
 def test_make_silence_missing_ffmpeg(monkeypatch, tmp_path):
     monkeypatch.setattr("bingbong.ffmpeg.find_ffmpeg", lambda: None)
-    with pytest.raises(RuntimeError, match="ffmpeg is not available"):
+    with pytest.raises(BingBongError, match="ffmpeg is not available"):
         ffmpeg.make_silence(tmp_path)


### PR DESCRIPTION
## Summary
- add `dryable` decorator to centralize CLI dry-run handling
- introduce `BingBongError` and refactor ffmpeg helpers to use Path
- document `ChimeScheduler` API and update tests for new error

## Testing
- `ruff check .`
- `ruff format tests/conftest.py tests/test_ffmpeg.py src/bingbong/cli.py src/bingbong/commands/build.py src/bingbong/ffmpeg.py src/bingbong/scheduler.py src/bingbong/utils.py src/bingbong/__init__.py src/bingbong/errors.py`
- `pytest -q`


------
https://chatgpt.com/codex/tasks/task_e_6896611fa7ec8327938b1610b4265238