### PR TITLE
feat: add advanced launchd controls

### DIFF
--- a/TODO.md
+++ b/TODO.md
@@ -1,8 +1,8 @@
-- [ ] Expose advanced `LaunchBehavior` knobs
+- [x] Expose advanced `LaunchBehavior` knobs
   - Add CLI/config options to set `exit_timeout`, `throttle_interval`, `successful_exit`, and `crashed`.
 - [ ] Replace polling for wake detection
   - Replace `on_wake` polling with a `SystemWake` event via `EventTriggers`.
-- [ ] Backoff on failure
+- [x] Backoff on failure
   - Add `--backoff <seconds>` flag and use it to set `ThrottleInterval` and `KeepAlive = {"Crashed": True}`.
 - [ ] Auto-reload on config change
   - Use `FilesystemTriggers.add_watch_path()` on `~/.config/bingbong/config.toml` to restart service after edits.
@@ -10,11 +10,11 @@
   - Centralize verbosity and formatting control (currently spread across modules).
 - [ ] Document all CLI/config options
   - Update `README.md` and CLI `--help` output to include advanced scheduling and behavior flags.
-- [ ] Wrap `ffmpeg` in a testable class
+- [x] Wrap `ffmpeg` in a testable class
   - Create an injectable `FFmpeg` interface to isolate subprocess logic.
-- [ ] Unify state files
+- [x] Unify state files
   - Merge `.pause_until` and `.last_run` into a single JSON-backed state file.
-- [ ] Test `launchd` plist round-trip
+- [x] Test `launchd` plist round-trip
   - Generate a plist with `LaunchdService.render()`, then validate it using `plistlib.loads()`.
 - [ ] Test failure/backoff scenarios
   - Parametrize failures and confirm expected schedule behavior.

--- a/src/bingbong/audio.py
+++ b/src/bingbong/audio.py
@@ -6,7 +6,7 @@ from pathlib import Path
 import sounddevice as sd
 import soundfile as sf
 
-from .ffmpeg import concat, make_silence
+from .ffmpeg import FFmpeg, concat, make_silence
 from .paths import ensure_outdir
 
 # --- Constants ---
@@ -45,16 +45,16 @@ def duck_others() -> None:
     return
 
 
-def make_quarters(outdir: Path | None = None) -> None:
+def make_quarters(outdir: Path | None = None, ffmpeg: FFmpeg | None = None) -> None:
     if outdir is None:
         outdir = ensure_outdir()
     for n in range(1, 4):
         pops = [POP] * n
         output = outdir / f"quarter_{n}.wav"
-        concat([str(outdir / "silence.wav"), *pops], output, outdir=outdir)
+        concat([str(outdir / "silence.wav"), *pops], output, outdir=outdir, runner=ffmpeg)
 
 
-def make_hours(outdir: Path | None = None) -> None:
+def make_hours(outdir: Path | None = None, ffmpeg: FFmpeg | None = None) -> None:
     if outdir is None:
         outdir = ensure_outdir()
     for hour in range(1, 13):
@@ -68,10 +68,10 @@ def make_hours(outdir: Path | None = None) -> None:
                 cluster.extend([POP] * remaining_ + [SILENCE])
 
         output = outdir / f"hour_{hour}.wav"
-        concat([SILENCE, CHIME, SILENCE, *cluster], output, outdir=outdir)
+        concat([SILENCE, CHIME, SILENCE, *cluster], output, outdir=outdir, runner=ffmpeg)
 
 
-def build_all(outdir: Path | None = None) -> None:
-    make_silence(outdir)
-    make_quarters(outdir)
-    make_hours(outdir)
+def build_all(outdir: Path | None = None, ffmpeg: FFmpeg | None = None) -> None:
+    make_silence(outdir, runner=ffmpeg)
+    make_quarters(outdir, ffmpeg=ffmpeg)
+    make_hours(outdir, ffmpeg=ffmpeg)

--- a/src/bingbong/commands/build.py
+++ b/src/bingbong/commands/build.py
@@ -2,10 +2,9 @@ from __future__ import annotations
 
 import click
 
-from bingbong import audio
+from bingbong import audio, ffmpeg
 from bingbong.console import err, ok
 from bingbong.errors import BingBongError
-from bingbong.ffmpeg import ffmpeg_available
 from bingbong.utils import dryable
 
 
@@ -14,7 +13,7 @@ from bingbong.utils import dryable
 @dryable("would build audio files")
 def build(_ctx: click.Context) -> None:
     """Build composite chime audio files."""
-    if not ffmpeg_available():
+    if not ffmpeg.ffmpeg_available():
         err("ffmpeg is not available")
         return
     try:

--- a/src/bingbong/scheduler.py
+++ b/src/bingbong/scheduler.py
@@ -22,6 +22,10 @@ class ChimeScheduler:
 
     chime_schedule: str = "0 * * * *"
     suppress_schedule: list[str] = field(default_factory=list)
+    exit_timeout: int | None = None
+    throttle_interval: int | None = None
+    successful_exit: bool | None = None
+    crashed: bool | None = None
 
     def __post_init__(self) -> None:
         """Validate cron expressions on init."""
@@ -44,4 +48,12 @@ def render(cfg: ChimeScheduler) -> LaunchdSchedule:
         sch.time.add_suppression_window(spec)
     sch.behavior.run_at_load = True
     sch.behavior.keep_alive = True
+    if cfg.exit_timeout is not None:
+        sch.behavior.exit_timeout = cfg.exit_timeout
+    if cfg.throttle_interval is not None:
+        sch.behavior.throttle_interval = cfg.throttle_interval
+    if cfg.successful_exit is not None:
+        sch.behavior.successful_exit = cfg.successful_exit
+    if cfg.crashed is not None:
+        sch.behavior.crashed = cfg.crashed
     return sch

--- a/src/bingbong/state.py
+++ b/src/bingbong/state.py
@@ -1,0 +1,37 @@
+from __future__ import annotations
+
+import json
+from typing import TYPE_CHECKING
+
+if TYPE_CHECKING:
+    from pathlib import Path
+
+STATE_FILE = ".state.json"
+
+
+def _state_path(outdir: Path) -> Path:
+    return outdir / STATE_FILE
+
+
+def load(outdir: Path) -> dict[str, str]:
+    """Load state from ``outdir``.
+
+    Returns an empty dictionary if the state file does not exist or is
+    malformed.
+    """
+    path = _state_path(outdir)
+    try:
+        data: dict[str, object] = json.loads(path.read_text(encoding="utf-8"))
+        if isinstance(data, dict):
+            return {str(k): str(v) for k, v in data.items()}
+    except OSError:
+        return {}
+    except json.JSONDecodeError:
+        path.unlink(missing_ok=True)
+    return {}
+
+
+def save(outdir: Path, state: dict[str, str]) -> None:
+    """Persist ``state`` to ``outdir``."""
+    path = _state_path(outdir)
+    _ = path.write_text(json.dumps(state), encoding="utf-8")

--- a/src/bingbong/utils.py
+++ b/src/bingbong/utils.py
@@ -3,7 +3,7 @@
 from __future__ import annotations
 
 import functools
-from typing import TYPE_CHECKING, ParamSpec, TypeVar
+from typing import TYPE_CHECKING, Concatenate, ParamSpec, TypeVar
 
 import click
 
@@ -14,7 +14,11 @@ P = ParamSpec("P")
 R = TypeVar("R")
 
 
-def dryable(message: str) -> Callable[[Callable[P, R]], Callable[P, R | None]]:
+def dryable(
+    message: str,
+) -> Callable[
+    [Callable[Concatenate[click.Context, P], R]], Callable[Concatenate[click.Context, P], R | None]
+]:
     """Skip command execution when ``--dry-run`` is set.
 
     Parameters
@@ -23,7 +27,9 @@ def dryable(message: str) -> Callable[[Callable[P, R]], Callable[P, R | None]]:
         Description of the action that would have been performed.
     """
 
-    def decorator(func: Callable[P, R]) -> Callable[P, R | None]:
+    def decorator(
+        func: Callable[Concatenate[click.Context, P], R],
+    ) -> Callable[Concatenate[click.Context, P], R | None]:
         @functools.wraps(func)
         def wrapper(ctx: click.Context, *args: P.args, **kwargs: P.kwargs) -> R | None:
             if ctx.obj.get("dry_run"):

--- a/tests/test_scheduler.py
+++ b/tests/test_scheduler.py
@@ -20,3 +20,17 @@ def test_render_suppression():
     cfg = ChimeScheduler(suppress_schedule=["5 2 * * *"])
     sch = render(cfg)
     assert {"Hour": 2, "Minute": 5} in sch.time.calendar_entries
+
+
+def test_render_behavior_options():
+    cfg = ChimeScheduler(
+        exit_timeout=10,
+        throttle_interval=20,
+        successful_exit=False,
+        crashed=True,
+    )
+    sch = render(cfg)
+    assert sch.behavior.exit_timeout == 10
+    assert sch.behavior.throttle_interval == 20
+    assert sch.behavior.successful_exit is False
+    assert sch.behavior.crashed is True

--- a/tests/test_service.py
+++ b/tests/test_service.py
@@ -1,0 +1,24 @@
+import plistlib
+import subprocess
+
+from bingbong import paths, scheduler, service
+
+
+def test_plist_round_trip(tmp_path, monkeypatch):
+    monkeypatch.setattr(paths, "ensure_outdir", lambda: tmp_path)
+
+    class DummyLC:
+        def load(self, path):
+            return subprocess.CompletedProcess([], 0)
+
+        def unload(self, path):
+            return subprocess.CompletedProcess([], 0)
+
+    monkeypatch.setattr("onginred.service.LaunchctlClient", DummyLC)
+
+    cfg = scheduler.ChimeScheduler()
+    svc = service._service(cfg)
+    plist_dict = svc.to_plist_dict()
+    blob = plistlib.dumps(plist_dict)
+    loaded = plistlib.loads(blob)
+    assert loaded == plist_dict


### PR DESCRIPTION
## Summary
- add CLI options to tune launchd behavior and backoff strategy
- wrap ffmpeg helper in injectable class and merge state files
- add plist round-trip test

## Testing
- `ruff check`
- `uv run basedpyright src/bingbong/ffmpeg.py src/bingbong/audio.py src/bingbong/notify.py src/bingbong/commands/silence.py src/bingbong/commands/build.py src/bingbong/scheduler.py src/bingbong/state.py src/bingbong/cli.py src/bingbong/utils.py`
- `uv run pytest`


------
https://chatgpt.com/codex/tasks/task_e_6896b01f11b88327aee68ac02f387406