### PR TITLE
feat: parse suppression windows and log chimes

### DIFF
--- a/src/bingbong/notify.py
+++ b/src/bingbong/notify.py
@@ -6,6 +6,7 @@ from pathlib import Path
 
 from . import audio, state
 from .audio import build_all
+from .console import ok
 from .paths import ensure_outdir
 
 logger = logging.getLogger("bingbong.notify")
@@ -132,7 +133,7 @@ def notify_time(outdir: Path | None = None) -> None:
         logger.warning("warning: %s", e)
 
     # 6) Play the chime
-    print(f"{now.isoformat()} {chime_path.name}")
+    ok(f"{now.isoformat()} {chime_path.name}")
     audio.play_file(chime_path)
 
 
@@ -163,7 +164,7 @@ def on_wake(outdir: Path | None = None) -> None:
         current += timedelta(hours=1)
         path = resolve_chime_path(current.hour, 0, outdir)
         if path.exists():
-            print(f"{current.isoformat()} {path.name}")
+            ok(f"{current.isoformat()} {path.name}")
             audio.play_file(path)
 
     data["last_run"] = now.isoformat()

--- a/tests/test_notify.py
+++ b/tests/test_notify.py
@@ -211,15 +211,18 @@ def test_notify_respects_dnd(tmp_path, monkeypatch):
 
 
 @freeze_time("2024-01-01 15:00:00")
-def test_on_wake_plays_missed_chimes(tmp_path, monkeypatch):
+def test_on_wake_plays_missed_chimes(tmp_path, monkeypatch, capsys):
     audio.build_all(tmp_path)
     state_file = tmp_path / ".state.json"
     state_file.write_text(json.dumps({"last_run": "2024-01-01T12:00:00"}))
     played: list[str] = []
     monkeypatch.setattr("bingbong.audio.play_file", lambda p: played.append(Path(p).name))
     notify.on_wake(outdir=tmp_path)
+    out = capsys.readouterr().out
     assert "hour_2.wav" in played
     assert "hour_3.wav" in played
+    assert "hour_2.wav" in out
+    assert "hour_3.wav" in out
     data = json.loads(state_file.read_text())
     assert data["last_run"].startswith("2024-01-01T15:00:00")
 


### PR DESCRIPTION
## Summary
- parse HH:MM-HH:MM suppression window strings and validate them
- log played chimes via console instead of print, including on wake
- add tests for suppression windows, overnight handling, and wake logging

## Testing
- `ruff check src/bingbong/scheduler.py src/bingbong/notify.py tests/test_scheduler.py tests/test_notify.py`
- `PYTHONPATH=src pytest -q`


------
https://chatgpt.com/codex/tasks/task_e_6897dd9cc7bc8327b9921c0bcb50a57c