### PR TITLE
test: fix imports for source package

### DIFF
--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -5,6 +5,9 @@ from pathlib import Path
 
 import pytest
 
+ROOT = Path(__file__).resolve().parents[1]
+sys.path.insert(0, str(ROOT / "src"))
+
 MAX_OUTPUT_LINES = 32
 
 # Provide dummy sounddevice/soundfile modules so tests don't require system libs


### PR DESCRIPTION
## Summary
- ensure tests can import bingbong by inserting src path early

## Testing
- `ruff check`
- `pytest -q`


------
https://chatgpt.com/codex/tasks/task_e_6897df863990832791f2b3973dabcd12